### PR TITLE
Add buildifier linting to CI and improve formatting documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           repository-cache: true
 
       - name: Lint and check BUILD file formatting (buildifier)
-        run: bazel run //tools/format:buildifier.check
+        run: bazel run //tools/format:format.check
 
       - name: Build all targets
         run: bazel build //...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
 
+      - name: Lint and check BUILD file formatting (buildifier)
+        run: bazel run //tools/format:buildifier.check
+
       - name: Build all targets
         run: bazel build //...
 
       - name: Test all targets
         run: bazel test //... --test_output=errors
-
-      # TODO: Add buildifier format check step once we determine the proper
-      # approach for running buildifier in CI (see issue for options)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,3 +9,9 @@ python_grpc_compile(
     name = "greeter_python_grpc",
     protos = ["@rules_proto_grpc_example_protos//:greeter_grpc"],
 )
+
+# Convenience alias for formatting - run with: bazel run //:format
+alias(
+    name = "format",
+    actual = "//tools/format",
+)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,7 +95,21 @@ bazel test --test_output=all //...
 
 ## Code Formatting and Linting
 
-This project uses `aspect_rules_lint` and `buildifier_prebuilt` for code formatting.
+This project uses `aspect_rules_lint` and `buildifier_prebuilt` for BUILD file formatting and linting.
+
+### Quick Commands
+
+```bash
+# Format and fix lint issues in all BUILD/Starlark files
+bazel run //tools/format:buildifier
+
+# Check formatting and lint without making changes (used in CI)
+bazel run //tools/format:buildifier.check
+```
+
+### Alternative Format Commands
+
+The following targets use `format_multirun` for broader formatting support:
 
 ```bash
 # Format all BUILD files
@@ -104,6 +118,15 @@ bazel run //tools/format:format
 # Check formatting without making changes
 bazel run //tools/format:format.check
 ```
+
+### About Buildifier
+
+[Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier) is the standard formatter and linter for Bazel BUILD and `.bzl` files. It enforces consistent style and catches common issues like:
+
+- Unused load statements
+- Undocumented public functions
+- Deprecated function usage
+- Incorrect package ordering
 
 ## Dependency Management
 
@@ -205,5 +228,6 @@ git diff tools/requirements.txt
 When making changes:
 1. Follow the existing code style and structure
 2. Update this DEVELOPMENT.md if you change the build process or dependencies
-3. Run formatters before committing: `bazel run //tools/format:format`
+3. Run formatters and linters before committing: `bazel run //tools/format:buildifier`
 4. Ensure all tests pass: `bazel test //...`
+5. Verify lint checks pass: `bazel run //tools/format:buildifier.check`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,27 +95,17 @@ bazel test --test_output=all //...
 
 ## Code Formatting and Linting
 
-This project uses `aspect_rules_lint` and `buildifier_prebuilt` for BUILD file formatting and linting.
+This project uses [`aspect_rules_lint`](https://github.com/aspect-build/rules_lint) with `buildifier_prebuilt` for BUILD file formatting and linting.
 
 ### Quick Commands
 
 ```bash
 # Format and fix lint issues in all BUILD/Starlark files
-bazel run //tools/format:buildifier
+bazel run //:format
+# Or equivalently:
+bazel run //tools/format
 
 # Check formatting and lint without making changes (used in CI)
-bazel run //tools/format:buildifier.check
-```
-
-### Alternative Format Commands
-
-The following targets use `format_multirun` for broader formatting support:
-
-```bash
-# Format all BUILD files
-bazel run //tools/format:format
-
-# Check formatting without making changes
 bazel run //tools/format:format.check
 ```
 
@@ -127,6 +117,8 @@ bazel run //tools/format:format.check
 - Undocumented public functions
 - Deprecated function usage
 - Incorrect package ordering
+
+For more details on the formatting setup, see the [aspect_rules_lint formatting docs](https://github.com/aspect-build/rules_lint/blob/main/docs/formatting.md).
 
 ## Dependency Management
 
@@ -228,6 +220,6 @@ git diff tools/requirements.txt
 When making changes:
 1. Follow the existing code style and structure
 2. Update this DEVELOPMENT.md if you change the build process or dependencies
-3. Run formatters and linters before committing: `bazel run //tools/format:buildifier`
+3. Run formatters and linters before committing: `bazel run //:format`
 4. Ensure all tests pass: `bazel test //...`
-5. Verify lint checks pass: `bazel run //tools/format:buildifier.check`
+5. Verify lint checks pass: `bazel run //tools/format:format.check`

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,5 +44,5 @@ register_toolchains(
 )
 
 # For formatting rules
-bazel_dep(name = "aspect_rules_lint", version = "1.0.3")
+bazel_dep(name = "aspect_rules_lint", version = "2.0.0")
 bazel_dep(name = "buildifier_prebuilt", version = "6.3.3")

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -1,30 +1,19 @@
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
+# Formatting and linting for Starlark/BUILD files using buildifier
+# See: https://github.com/aspect-build/rules_lint/blob/main/docs/formatting.md
+#
+# Usage:
+#   bazel run //tools/format         # Format and fix lint issues
+#   bazel run //tools/format:format.check  # Check without modifying (for CI)
+#
+# Or from the root (via alias):
+#   bazel run //:format
 format_multirun(
     name = "format",
     starlark = "@buildifier_prebuilt//:buildifier",
+    # Enable buildifier linting in addition to formatting
+    starlark_check_args = ["--lint=warn"],
+    starlark_fix_args = ["--lint=fix"],
     visibility = ["//visibility:public"],
-)
-
-# Buildifier targets with linting support
-# Use "bazel run //tools/format:buildifier" to format and fix lint issues
-buildifier(
-    name = "buildifier",
-    exclude_patterns = [
-        "./.git/*",
-    ],
-    lint_mode = "fix",
-    mode = "fix",
-)
-
-# Use "bazel run //tools/format:buildifier.check" for CI checks
-# This will report formatting issues and lint warnings without modifying files
-buildifier(
-    name = "buildifier.check",
-    exclude_patterns = [
-        "./.git/*",
-    ],
-    lint_mode = "warn",
-    mode = "diff",
 )

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -1,7 +1,30 @@
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
 format_multirun(
     name = "format",
     starlark = "@buildifier_prebuilt//:buildifier",
     visibility = ["//visibility:public"],
+)
+
+# Buildifier targets with linting support
+# Use "bazel run //tools/format:buildifier" to format and fix lint issues
+buildifier(
+    name = "buildifier",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+# Use "bazel run //tools/format:buildifier.check" for CI checks
+# This will report formatting issues and lint warnings without modifying files
+buildifier(
+    name = "buildifier.check",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "warn",
+    mode = "diff",
 )


### PR DESCRIPTION
## Summary

- Add buildifier formatting and linting to CI workflow using `aspect_rules_lint`
- Configure `format_multirun` with lint mode following [official docs](https://github.com/aspect-build/rules_lint/blob/main/docs/formatting.md)
- Upgrade `aspect_rules_lint` to 2.0.0
- Add root alias for convenient `bazel run //:format` usage

## Changes

### CI Integration
- Added buildifier check step that runs before build/test
- Uses `//tools/format:format.check` which checks both formatting and lint warnings

### Formatting Setup (`tools/format/BUILD.bazel`)
- Uses `format_multirun` with `starlark_fix_args = ["--lint=fix"]` and `starlark_check_args = ["--lint=warn"]`
- Follows the recommended pattern from aspect_rules_lint docs

### Developer Experience
- Added `//:format` alias in root BUILD.bazel for easy access
- Updated DEVELOPMENT.md with usage instructions

## Usage

```bash
# Format and fix lint issues
bazel run //:format

# Check without modifying (used in CI)
bazel run //tools/format:format.check
